### PR TITLE
Apply ruff and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.0
+    hooks:
+    -   id: ruff
+    -   id: ruff-format

--- a/middleware.py
+++ b/middleware.py
@@ -23,10 +23,12 @@ class ResponseMiddleware:
                     print(e)
                 error = {
                     "status_code": response.status_code,
-                    "message": content["result"] if not has_content_html else response.reason_phrase
+                    "message": content["result"]
+                    if not has_content_html
+                    else response.reason_phrase,
                 }
                 content["error"] = error
                 content.pop("result")
-            
+
             response.content = json.dumps(content)
             return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.ruff]
+indent-width = 4
+line-length = 88
+target-version = "py38"
+cache-dir = "~/.cache/ruff"
+fix=true
+unsafe-fixes=true
+
+[tool.ruff.format]
+quote-style = "double"
+docstring-code-format = true
+skip-magic-trailing-comma = true
+line-ending = "auto"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "W", "F", "I"]
+
+[tool.ruff.lint.isort]
+length-sort = true


### PR DESCRIPTION
## 📌 Summary

Ruff와 Ruff를 자동화하기 위한 pre-commit을 적용했습니다.

## ⚡️ Ruff란?
파이썬 린터 및 코드 포매터로 기존(e.g. Flake8, Black)보다 훨씬 빠른 속도가 특징입니다.
다양한 Rule을 지원하여 Flake8, Black, isort, pydocstyle 등을 대체할 수 있는 갓갓 기능을 가지고 있답니다.

제가 적용한 [Rule](https://docs.astral.sh/ruff/rules/)은 아래와 같습니다.
- `E4`, `E7`, `E9`, `W`: [pycodestyle](https://pypi.org/project/pycodestyle/)
- `F`: [Pyflakes](https://pypi.org/project/pyflakes/)
- `I`: [isort](https://pycqa.github.io/isort/)









